### PR TITLE
Use unitttest discover, fix deprecation warnings in tests

### DIFF
--- a/plone/synchronize/tests.py
+++ b/plone/synchronize/tests.py
@@ -38,15 +38,8 @@ class Test(unittest.TestCase):
 
         self.assertEqual("one", item)
 
-        # raises exception
-
-        raised = False
-        try:
+        with self.assertRaises(IndexError):
             shared_stack.pop()
-        except IndexError:
-            raised = True
-
-        self.assertTrue(raised)
 
         # should not be dead-locked even after an exception
 

--- a/plone/synchronize/tests.py
+++ b/plone/synchronize/tests.py
@@ -36,7 +36,7 @@ class Test(unittest.TestCase):
         shared_stack.push("one")
         item = shared_stack.pop()
 
-        self.assertEquals("one", item)
+        self.assertEqual("one", item)
 
         # raises exception
 
@@ -46,14 +46,14 @@ class Test(unittest.TestCase):
         except IndexError:
             raised = True
 
-        self.failUnless(raised)
+        self.assertTrue(raised)
 
         # should not be dead-locked even after an exception
 
         shared_stack.push("two")
         item = shared_stack.pop()
 
-        self.assertEquals("two", item)
+        self.assertEqual("two", item)
 
     def test_function(self):
         global _global_list
@@ -63,7 +63,7 @@ class Test(unittest.TestCase):
         reverse_global_list()
         reverse_global_list()
 
-        self.assertEquals([3, 2, 1], _global_list)
+        self.assertEqual([3, 2, 1], _global_list)
 
 
 def test_suite():

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ envlist =
 
 [testenv]
 commands =
-    python setup.py test
+    python -m unittest discover -s plone/synchronize


### PR DESCRIPTION
This uses the suggestions from @jugmac00 in PR #2.

No significant change, so no news snippet.
No real code change, so no Jenkins jobs, only Travis.
